### PR TITLE
Improve MetaBaseModel aliases

### DIFF
--- a/src/model/abc.py
+++ b/src/model/abc.py
@@ -5,6 +5,7 @@ import datetime
 from weakref import WeakValueDictionary
 from flask.ext.sqlalchemy import SQLAlchemy
 from sqlalchemy import inspect
+from sqlalchemy.orm import aliased
 
 
 db = SQLAlchemy()
@@ -17,7 +18,7 @@ class MetaBaseModel(db.Model.__class__):
         try:
             alias = cls.aliases[key]
         except KeyError:
-            alias = cls.__table__.alias()
+            alias = aliased(cls)
             cls.aliases[key] = alias
         return alias
 


### PR DESCRIPTION
Use `sqlalchemy.orm.aliased` instead of `MyModel.__table__.alias`. Aliased produced this way "mimics the mapped class using a **getattr** scheme", ie you don't need to use `.c` to access your aliased table columns: `MyModel[0].my_column` instead of `MyModel[0].c.my_column.
