### PR TITLE
Ensure API doesn't listen to 0.0.0.0

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,7 @@
 import os, logging
 
 DEBUG = True
-HOST = os.getenv('HOST', '0.0.0.0')
+HOST = os.getenv('HOST')
 PORT = int(os.getenv('PORT', '5000'))
 
 POSTGRES = {


### PR DESCRIPTION
Most of our APIs listen to traffic on 0.0.0.0 because no 'HOST' variable is set.
I won't set a default HOST value so that when we create a new API based on this boilerplate we see it fails to run because the HOST env variable is not set.
